### PR TITLE
Crawl for geom_alt prop updates

### DIFF
--- a/data/856/325/69/85632569.geojson
+++ b/data/856/325/69/85632569.geojson
@@ -1016,6 +1016,10 @@
     },
     "wof:country":"VC",
     "wof:country_alpha3":"VCT",
+    "wof:geom_alt":[
+        "naturalearth",
+        "naturalearth-display-terrestrial-zoom6"
+    ],
     "wof:geomhash":"71a6a93d24452d11c830576dbab67bda",
     "wof:hierarchy":[
         {
@@ -1030,7 +1034,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1566644084,
+    "wof:lastmodified":1582393041,
     "wof:name":"Saint Vincent and the Grenadines",
     "wof:parent_id":102191575,
     "wof:placetype":"country",

--- a/data/890/429/321/890429321.geojson
+++ b/data/890/429/321/890429321.geojson
@@ -102,6 +102,9 @@
     },
     "wof:country":"VC",
     "wof:created":1469051810,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"8befe149645646bde03fade09858ae0b",
     "wof:hierarchy":[
         {
@@ -112,7 +115,7 @@
         }
     ],
     "wof:id":890429321,
-    "wof:lastmodified":1566644092,
+    "wof:lastmodified":1582393041,
     "wof:name":"Port Elizabeth",
     "wof:parent_id":85680437,
     "wof:placetype":"locality",

--- a/data/890/429/323/890429323.geojson
+++ b/data/890/429/323/890429323.geojson
@@ -327,6 +327,10 @@
     },
     "wof:country":"VC",
     "wof:created":1469051810,
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "unknown"
+    ],
     "wof:geomhash":"89d2ab92b0aca1c5d9f75194d65ac680",
     "wof:hierarchy":[
         {
@@ -337,7 +341,7 @@
         }
     ],
     "wof:id":890429323,
-    "wof:lastmodified":1566644092,
+    "wof:lastmodified":1582393041,
     "wof:name":"Kingstown",
     "wof:parent_id":85680451,
     "wof:placetype":"locality",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/1793

This PR:

- Adds a new `wof:geom_alt` property to any "default" WOF record that has an alt file, logic [here](https://github.com/whosonfirst-data/whosonfirst-data/issues/1793#issuecomment-587895012)
- Double checks existing `src:geom_alt` properties to ensure all alt file sources are accounted for in the property list. 

This will not require PIP work to update hierarchies.