### PR TITLE
add name properties from wikidata

### DIFF
--- a/data/112/593/918/5/1125939185.geojson
+++ b/data/112/593/918/5/1125939185.geojson
@@ -25,6 +25,9 @@
     "name:ara_x_preferred":[
         "\u062c\u0648\u0631\u062c\u062a\u0627\u0648\u0646"
     ],
+    "name:arz_x_preferred":[
+        "\u062c\u0648\u0631\u062c\u062a\u0627\u0648\u0646"
+    ],
     "name:ceb_x_preferred":[
         "Georgetown"
     ],
@@ -45,6 +48,9 @@
     ],
     "name:heb_x_preferred":[
         "\u05d2'\u05d5\u05e8\u05d2'\u05d8\u05d0\u05d5\u05df"
+    ],
+    "name:ita_x_preferred":[
+        "Georgetown"
     ],
     "name:jpn_x_preferred":[
         "\u30b8\u30e7\u30fc\u30b8\u30bf\u30a6\u30f3"
@@ -122,7 +128,7 @@
         }
     ],
     "wof:id":1125939185,
-    "wof:lastmodified":1636506374,
+    "wof:lastmodified":1690914895,
     "wof:name":"Georgetown",
     "wof:parent_id":85680433,
     "wof:placetype":"locality",

--- a/data/112/593/919/7/1125939197.geojson
+++ b/data/112/593/919/7/1125939197.geojson
@@ -31,6 +31,9 @@
     "name:eng_x_preferred":[
         "Byera Village"
     ],
+    "name:jpn_x_preferred":[
+        "\u30d0\u30a4\u30a8\u30e9\u30fb\u30f4\u30a3\u30ec\u30c3\u30b8"
+    ],
     "name:lit_x_preferred":[
         "Bjera Vilid\u017eas"
     ],
@@ -76,7 +79,7 @@
         }
     ],
     "wof:id":1125939197,
-    "wof:lastmodified":1566644093,
+    "wof:lastmodified":1690914896,
     "wof:name":"Byera Village",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/421/176/631/421176631.geojson
+++ b/data/421/176/631/421176631.geojson
@@ -17,6 +17,9 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:arz_x_preferred":[
+        "\u0645\u0648\u0633\u062a\u064a\u0643\u0648"
+    ],
     "name:bel_x_preferred":[
         "\u041c\u044e\u0441\u0442\u044b\u043a"
     ],
@@ -44,6 +47,9 @@
     "name:heb_x_preferred":[
         "\u05de\u05d5\u05e1\u05d8\u05d9\u05e7"
     ],
+    "name:ind_x_preferred":[
+        "Mustique"
+    ],
     "name:ita_x_preferred":[
         "Mustique"
     ],
@@ -52,6 +58,9 @@
     ],
     "name:lit_x_preferred":[
         "Miustikas"
+    ],
+    "name:mkd_x_preferred":[
+        "\u041c\u0443\u0441\u0442\u0438\u043a"
     ],
     "name:nld_x_preferred":[
         "Mustique"
@@ -120,7 +129,7 @@
         }
     ],
     "wof:id":421176631,
-    "wof:lastmodified":1566644091,
+    "wof:lastmodified":1690914893,
     "wof:name":"Mustique",
     "wof:parent_id":85680437,
     "wof:placetype":"locality",

--- a/data/421/200/993/421200993.geojson
+++ b/data/421/200/993/421200993.geojson
@@ -20,6 +20,9 @@
     "name:ara_x_preferred":[
         "\u0644\u0627\u064a\u0648"
     ],
+    "name:ast_x_preferred":[
+        "Layou"
+    ],
     "name:ceb_x_preferred":[
         "Layou"
     ],
@@ -29,7 +32,13 @@
     "name:eng_x_preferred":[
         "Layou"
     ],
+    "name:fas_x_preferred":[
+        "\u0644\u0627\u06cc\u0648"
+    ],
     "name:fra_x_preferred":[
+        "Layou"
+    ],
+    "name:ita_x_preferred":[
         "Layou"
     ],
     "name:jpn_x_preferred":[
@@ -37,6 +46,9 @@
     ],
     "name:lit_x_preferred":[
         "Laju"
+    ],
+    "name:mdf_x_preferred":[
+        "\u041b\u044d\u044e"
     ],
     "name:nld_x_preferred":[
         "Layou"
@@ -51,6 +63,12 @@
         "Layou"
     ],
     "name:rus_x_preferred":[
+        "\u041b\u0435\u044e"
+    ],
+    "name:szl_x_preferred":[
+        "Layou"
+    ],
+    "name:ukr_x_preferred":[
         "\u041b\u0435\u044e"
     ],
     "name:urd_x_preferred":[
@@ -104,7 +122,7 @@
         }
     ],
     "wof:id":421200993,
-    "wof:lastmodified":1566644091,
+    "wof:lastmodified":1690914892,
     "wof:name":"Layou",
     "wof:parent_id":85680443,
     "wof:placetype":"locality",

--- a/data/421/204/559/421204559.geojson
+++ b/data/421/204/559/421204559.geojson
@@ -17,6 +17,9 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:arz_x_preferred":[
+        "\u0643\u0627\u0646\u0648\u0627\u0646"
+    ],
     "name:aze_x_preferred":[
         "Kanuan adas\u0131"
     ],
@@ -56,6 +59,9 @@
     "name:lit_x_preferred":[
         "Kanuanas"
     ],
+    "name:mkd_x_preferred":[
+        "\u041a\u0430\u043d\u0443\u0430\u043d"
+    ],
     "name:nld_x_preferred":[
         "Canouan"
     ],
@@ -63,6 +69,9 @@
         "Canouan"
     ],
     "name:pol_x_preferred":[
+        "Canouan"
+    ],
+    "name:por_x_preferred":[
         "Canouan"
     ],
     "name:rus_x_preferred":[
@@ -76,6 +85,9 @@
     ],
     "name:ukr_x_preferred":[
         "\u041a\u0430\u043d\u0443\u0430\u043d"
+    ],
+    "name:wuu_x_preferred":[
+        "\u5361\u52aa\u5b89\u5c9b"
     ],
     "name:zho_x_preferred":[
         "\u5361\u52aa\u5b89\u5cf6"
@@ -123,7 +135,7 @@
         }
     ],
     "wof:id":421204559,
-    "wof:lastmodified":1566644091,
+    "wof:lastmodified":1690914892,
     "wof:name":"Canouan",
     "wof:parent_id":85680437,
     "wof:placetype":"locality",

--- a/data/856/325/69/85632569.geojson
+++ b/data/856/325/69/85632569.geojson
@@ -38,6 +38,9 @@
     "name:aka_x_preferred":[
         "Saint Vincent ne Grenadines"
     ],
+    "name:aka_x_variant":[
+        "Saint Vincent and the Grenadines"
+    ],
     "name:als_x_preferred":[
         "St. Vincent und die Grenadinen"
     ],
@@ -46,6 +49,15 @@
     ],
     "name:amh_x_variant":[
         "\u1245\u12f1\u1235 \u126a\u1295\u1234\u1295\u1275 \u12a5\u1293 \u130d\u122c\u1293\u12f2\u1295\u1235"
+    ],
+    "name:ami_x_preferred":[
+        "Saint Vincent and the Grenadines"
+    ],
+    "name:ang_x_preferred":[
+        "Halga Uincentius and \u00fea Grenadingas"
+    ],
+    "name:anp_x_preferred":[
+        "\u0938\u0947\u0902\u091f \u0935\u093f\u0902\u0938\u0947\u0902\u091f \u0906\u0930\u094b \u0917\u094d\u0930\u0947\u0928\u093e\u0921\u093e\u0907\u0928\u094d\u0938"
     ],
     "name:ara_x_preferred":[
         "\u0633\u0627\u0646\u062a \u0641\u064a\u0646\u0633\u0646\u062a \u0648\u0627\u0644\u063a\u0631\u064a\u0646\u0627\u062f\u064a\u0646"
@@ -57,6 +69,9 @@
     ],
     "name:arg_x_preferred":[
         "Sant Vicent y as Granadinas"
+    ],
+    "name:ary_x_preferred":[
+        "\u0633\u0627\u0646 \u06a4\u064a\u0646\u0633\u0646\u062a \u0624\u0644\u06ad\u0631\u0646\u0627\u062f\u064a\u0646\u0632"
     ],
     "name:arz_x_preferred":[
         "\u0633\u0627\u0646\u062a \u0641\u064a\u0646\u0633\u064a\u0646\u062a \u0648 \u0627\u0644\u062c\u0631\u064a\u0646\u0627\u062f\u064a\u0646\u0632"
@@ -87,6 +102,9 @@
     "name:bam_x_preferred":[
         "Vinis\u025bn-Senu-ni-Grenadini"
     ],
+    "name:ban_x_preferred":[
+        "Saint Vinc\u00e9nt miwah Gr\u00e9nadines"
+    ],
     "name:bar_x_preferred":[
         "St. Vincent und de Grenadinen"
     ],
@@ -104,7 +122,11 @@
         "\u09b8\u09c7\u09a8\u09cd\u099f \u09ad\u09bf\u09a8\u09b8\u09c7\u09a8\u09cd\u099f \u0993 \u0997\u09cd\u09b0\u09c7\u09a8\u09be\u09a1\u09be\u0987\u09a8 \u09a6\u09cd\u09ac\u09c0\u09aa\u09aa\u09c1\u099e\u09cd\u099c"
     ],
     "name:ben_x_variant":[
-        "\u09b8\u09c7\u09a8\u09cd\u099f \u09ad\u09bf\u09a8\u09b8\u09c7\u09a8\u09cd\u099f \u0993 \u09a6\u09cd\u09af\u09be \u0997\u09cd\u09b0\u09c7\u09a8\u09be\u09a1\u09bf\u09a8\u09b8"
+        "\u09b8\u09c7\u09a8\u09cd\u099f \u09ad\u09bf\u09a8\u09b8\u09c7\u09a8\u09cd\u099f \u0993 \u09a6\u09cd\u09af\u09be \u0997\u09cd\u09b0\u09c7\u09a8\u09be\u09a1\u09bf\u09a8\u09b8",
+        "\u09b8\u09c7\u09a8\u09cd\u099f \u09ad\u09bf\u09a8\u09b8\u09c7\u09a8\u09cd\u099f \u0993 \u0997\u09cd\u09b0\u09c7\u09a8\u09be\u09a1\u09be\u0987\u09a8"
+    ],
+    "name:bis_x_preferred":[
+        "Sen-Vinsen mo Grenadin"
     ],
     "name:bod_x_preferred":[
         "\u0f66\u0f7a\u0f53\u0f0b\u0f4a\u0f72\u0f0b\u0f56\u0f72\u0f53\u0f0b\u0f66\u0f7a\u0f53\u0f0b\u0f4a\u0f72\u0f0b\u0f51\u0f44\u0f0b\u0f42\u0f72\u0f0b\u0f62\u0f72\u0f0b\u0f53\u0f0b\u0f4c\u0f72\u0f53\u0f0b\u0f66\u0f72\u0f0d"
@@ -169,6 +191,9 @@
     "name:cor_x_preferred":[
         "Sen Vinsent ha'n Ynysow Grenadinek"
     ],
+    "name:cos_x_preferred":[
+        "Saint Vincent \u00e8 Grenadini"
+    ],
     "name:crh_x_preferred":[
         "Sent Vinsent ve Grenadinler"
     ],
@@ -176,7 +201,11 @@
         "Saint Vincent a'r Grenadines"
     ],
     "name:cym_x_variant":[
-        "Saint Vincent a\u2019r Grenadines"
+        "Saint Vincent a\u2019r Grenadines",
+        "Sant Vincent a'r Grenadines"
+    ],
+    "name:dag_x_preferred":[
+        "St. Vincent & Grenadines"
     ],
     "name:dan_x_preferred":[
         "Saint Vincent og Grenadinerne"
@@ -189,6 +218,9 @@
     ],
     "name:deu_x_variant":[
         "St. Vincent und Grenadinen"
+    ],
+    "name:diq_x_preferred":[
+        "Saint Vincent u Grenadinan"
     ],
     "name:div_x_preferred":[
         "\u0790\u07a6\u0782\u07b0\u078c\u07a8 \u0788\u07a8\u0790\u07ac\u0782\u07b0\u0793\u07ad \u0787\u07a6\u078b\u07a8 \u078e\u07aa\u0783\u07ac\u0782\u07a7\u0791\u07a9\u0782\u07b0"
@@ -284,6 +316,9 @@
     ],
     "name:frr_x_preferred":[
         "St. Vincent an Grenadiinen"
+    ],
+    "name:frr_x_variant":[
+        "St. Vincent an a Grenadiinen"
     ],
     "name:fry_x_preferred":[
         "Sint-Finsint en de Grenadinen"
@@ -432,6 +467,9 @@
     "name:jpn_x_variant":[
         "\u30bb\u30f3\u30c8\u30d3\u30f3\u30bb\u30f3\u30c8\u30fb\u30b0\u30ec\u30ca\u30c7\u30a3\u30fc\u30f3\u8af8\u5cf6"
     ],
+    "name:kaa_x_preferred":[
+        "Sent-vinsent ha'm Grenadin"
+    ],
     "name:kab_x_preferred":[
         "Saint Vincent ed Grenadines"
     ],
@@ -499,6 +537,9 @@
     "name:lit_x_variant":[
         "\u0160ventasis Vincentas ir Grenadinai"
     ],
+    "name:lld_x_preferred":[
+        "San Zenz y la Grenadines"
+    ],
     "name:lmo_x_preferred":[
         "San Vincenz e Grenadin"
     ],
@@ -514,6 +555,9 @@
     "name:lug_x_preferred":[
         "Senti Vinsenti ne Gurendadiini"
     ],
+    "name:mad_x_preferred":[
+        "Saint Vincent b\u00e2n The Grenadines"
+    ],
     "name:mal_x_preferred":[
         "\u0d38\u0d46\u0d2f\u0d4d\u0d28\u0d4d\u0d31\u0d4d \u0d35\u0d3f\u0d7b\u0d38\u0d28\u0d4d\u0d31\u0d4d \u0d17\u0d4d\u0d30\u0d28\u0d21\u0d40\u0d7b\u0d38\u0d4d"
     ],
@@ -525,6 +569,15 @@
     ],
     "name:mar_x_variant":[
         "\u0938\u0947\u0902\u091f \u0935\u094d\u0939\u093f\u0928\u094d\u0938\u0947\u0902\u091f \u0906\u0923\u093f \u0917\u094d\u0930\u0947\u0928\u0921\u093e\u0907\u0928\u094d\u0938"
+    ],
+    "name:mdf_x_preferred":[
+        "\u0421\u044d\u043d\u0442-\u0412\u0438\u043d\u0441\u044d\u043d\u0442 \u0434\u044b \u0413\u0440\u044d\u043d\u0430\u0434\u0438\u043d\u0442"
+    ],
+    "name:mhr_x_preferred":[
+        "\u0421\u0435\u043d\u0442-\u0412\u0438\u043d\u0441\u0435\u043d\u0442 \u0434\u0430 \u0413\u0440\u0435\u043d\u0430\u0434\u0438\u043d"
+    ],
+    "name:min_x_preferred":[
+        "Saint Vincent jo Grenadine"
     ],
     "name:mkd_x_preferred":[
         "\u0421\u0432\u0435\u0442\u0438 \u0412\u0438\u043d\u0446\u0435\u043d\u0442 \u0438 \u0413\u0440\u0435\u043d\u0430\u0434\u0438\u043d\u0438"
@@ -543,6 +596,12 @@
     ],
     "name:mlt_x_variant":[
         "Saint Vincent and the Grenadines"
+    ],
+    "name:mni_x_preferred":[
+        "\uabc1\uabe6\uabdf\uabe0 \uabda\uabe4\uabdf\uabc1\uabe6\uabdf\uabe0 \uabd1\uabc3\uabd7\uabe4 \uabd2\uabed\uabd4\uabe6\uabc5\uabe5\uabd7\uabe4\uabdf\uabc1"
+    ],
+    "name:mri_x_preferred":[
+        "Hato W\u0113neti me ng\u0101 Kerenar\u012bna"
     ],
     "name:msa_x_preferred":[
         "Saint Vincent dan Grenadines"
@@ -689,6 +748,9 @@
     "name:sgs_x_preferred":[
         "Sent Vinsents \u0117r Gr\u0117nadin\u0101"
     ],
+    "name:shn_x_preferred":[
+        "\u1019\u102d\u1030\u1004\u103a\u1038\u101e\u1035\u1004\u103a\u1089\u101d\u102d\u107c\u103a\u1038\u101e\u1085\u107c\u103a\u1089 \u101c\u1084\u1088 \u1075\u101b\u1084\u1038\u107c\u1083\u1038\u1010\u102d\u107c\u103a\u1038"
+    ],
     "name:sin_x_preferred":[
         "\u0dc1\u0dcf\u0db1\u0dca\u0dad \u0dc0\u0dd2\u0db1\u0dca\u0dc3\u0db1\u0dca\u0da7\u0dca \u0dc3\u0dc4 \u0d9c\u0dca\u200d\u0dbb\u0dd9\u0db1\u0dcf\u0da9\u0dd2\u0db1\u0dca\u0dc3\u0dca"
     ],
@@ -711,8 +773,20 @@
     "name:sme_x_variant":[
         "Saint Vincent ja Grenadiinnat"
     ],
+    "name:smn_x_preferred":[
+        "Saint Vincent j\u00e1 Grenadiineh"
+    ],
+    "name:smo_x_preferred":[
+        "Saint Vincent ma Grenadine"
+    ],
+    "name:sms_x_preferred":[
+        "Saint Vincent da Grenadiin"
+    ],
     "name:sna_x_preferred":[
         "Saint Vincent and the Grenadines"
+    ],
+    "name:snd_x_preferred":[
+        "\u0633\u064a\u0646\u067d \u0648\u0646\u0633\u0646\u067d \u06fd \u06af\u0631\u064a\u0646\u0627\u068a\u0627\u0626\u0646\u0632"
     ],
     "name:som_x_preferred":[
         "Saint Vincent and the Grenadines"
@@ -730,6 +804,9 @@
     ],
     "name:sqi_x_variant":[
         "Saint Vincent e Grenadinet"
+    ],
+    "name:srd_x_preferred":[
+        "Saint Vincent e sas Grenadinas"
     ],
     "name:srp_x_preferred":[
         "\u0421\u0435\u043d\u0442 \u0412\u0438\u043d\u0441\u0435\u043d\u0442 \u0438 \u0413\u0440\u0435\u043d\u0430\u0434\u0438\u043d\u0438"
@@ -775,6 +852,9 @@
     "name:tet_x_preferred":[
         "Saun Visente no Granadinas"
     ],
+    "name:tgk_x_preferred":[
+        "\u0421\u0435\u043d\u0442-\u0412\u0438\u043d\u0441\u0435\u043d\u0442 \u0432\u0430 \u0413\u0440\u0435\u043d\u0430\u0434\u0438\u043d\u04b3\u043e"
+    ],
     "name:tgl_x_preferred":[
         "Saint Vincent and the Grenadines"
     ],
@@ -793,14 +873,23 @@
     "name:ton_x_preferred":[
         "Seini Viniseni mo Kulenatini"
     ],
+    "name:ton_x_variant":[
+        "S\u0101 Viniseni mo Kulenatini"
+    ],
     "name:tuk_x_preferred":[
         "Sent-Winsent we Grenadin"
+    ],
+    "name:tum_x_preferred":[
+        "Saint Vincent na Grenadines"
     ],
     "name:tur_x_preferred":[
         "Saint Vincent ve Grenadinler"
     ],
     "name:tur_x_variant":[
         "Saint Vincent ve Grenadines"
+    ],
+    "name:udm_x_preferred":[
+        "\u0421\u0435\u043d\u0442-\u0412\u0438\u043d\u0441\u0435\u043d\u0442 \u043d\u043e \u0413\u0440\u0435\u043d\u0430\u0434\u0438\u043d"
     ],
     "name:uig_x_preferred":[
         "\u0633\u06d0\u0646\u062a \u06cb\u0649\u0646\u0633\u06d0\u0646\u062a \u06cb\u06d5 \u06af\u0631\u06d0\u0646\u0627\u062f\u0649\u0646 \u0626\u0627\u0631\u0627\u0644\u0644\u0649\u0631\u0649"
@@ -824,6 +913,9 @@
     ],
     "name:uzb_x_preferred":[
         "Sent Vinsent va Grenadinlar"
+    ],
+    "name:vec_x_preferred":[
+        "St. Vincent e Grenadine"
     ],
     "name:vep_x_preferred":[
         "Sent Vinsent da Grenadinad"
@@ -1093,7 +1185,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1617827727,
+    "wof:lastmodified":1690914891,
     "wof:name":"Saint Vincent and the Grenadines",
     "wof:parent_id":102191575,
     "wof:placetype":"country",

--- a/data/856/804/33/85680433.geojson
+++ b/data/856/804/33/85680433.geojson
@@ -53,6 +53,12 @@
     "name:eng_x_variant":[
         "Charlotte Parish"
     ],
+    "name:epo_x_preferred":[
+        "Paro\u0125o \u0108arloto"
+    ],
+    "name:eus_x_preferred":[
+        "Charlotte parrokia"
+    ],
     "name:fas_x_preferred":[
         "\u0634\u0627\u0631\u0644\u0648\u062a \u067e\u0631\u06cc\u0634\u060c \u0633\u0646\u062a \u0648\u06cc\u0646\u0633\u0646\u062a \u0648 \u06af\u0631\u0646\u0627\u062f\u06cc\u0646\u200c\u0647\u0627"
     ],
@@ -92,6 +98,9 @@
     "name:kor_x_preferred":[
         "\uc0ec\ub7ff \uad50\uad6c"
     ],
+    "name:kor_x_variant":[
+        "\uc0ec\ub7ff\uad6c"
+    ],
     "name:lav_x_preferred":[
         "\u0160arlotes pagasts"
     ],
@@ -112,6 +121,9 @@
     ],
     "name:nob_x_preferred":[
         "Charlotte prestegjeld"
+    ],
+    "name:nob_x_variant":[
+        "Charlotte Parish"
     ],
     "name:nor_x_preferred":[
         "Charlotte prestegjeld"
@@ -283,7 +295,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1636506372,
+    "wof:lastmodified":1690914889,
     "wof:name":"Charlotte",
     "wof:parent_id":85632569,
     "wof:placetype":"region",

--- a/data/856/804/37/85680437.geojson
+++ b/data/856/804/37/85680437.geojson
@@ -56,6 +56,12 @@
     "name:eng_x_variant":[
         "Grenadines Parish"
     ],
+    "name:epo_x_preferred":[
+        "Paro\u0125o Grenadinoj"
+    ],
+    "name:eus_x_preferred":[
+        "Grenadinak parrokia"
+    ],
     "name:fas_x_preferred":[
         "\u06af\u0631\u0646\u0627\u062f\u06cc\u0646\u200c\u0647\u0627 \u067e\u0631\u06cc\u0634"
     ],
@@ -83,8 +89,14 @@
     "name:kor_x_preferred":[
         "\uadf8\ub808\ub098\ub518 \uad50\uad6c"
     ],
+    "name:kor_x_variant":[
+        "\uadf8\ub808\ub098\ub518\uad6c"
+    ],
     "name:lit_x_preferred":[
         "Grenadin\u0173 parapija"
+    ],
+    "name:mkd_x_preferred":[
+        "\u0413\u0440\u0435\u043d\u0430\u0434\u0438\u043d\u0438"
     ],
     "name:nld_x_preferred":[
         "Grenadines Parish"
@@ -94,6 +106,9 @@
     ],
     "name:nob_x_preferred":[
         "Grenadines prestegjeld"
+    ],
+    "name:nob_x_variant":[
+        "Grenadines Parish"
     ],
     "name:nor_x_preferred":[
         "Grenadinene"
@@ -118,6 +133,9 @@
     ],
     "name:ukr_x_preferred":[
         "\u0490\u0440\u0435\u043d\u0430\u0434\u0456\u043d\u0438"
+    ],
+    "name:ukr_x_variant":[
+        "\u0413\u0440\u0435\u043d\u0430\u0434\u0438\u043d\u0438"
     ],
     "name:urd_x_preferred":[
         "\u06af\u0631\u06cc\u0646\u0627\u0688\u0627\u0626\u0646\u0632 \u067e\u06cc\u0631\u0634"
@@ -244,7 +262,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1636506372,
+    "wof:lastmodified":1690914890,
     "wof:name":"Grenadines",
     "wof:parent_id":85632569,
     "wof:placetype":"region",

--- a/data/856/804/43/85680443.geojson
+++ b/data/856/804/43/85680443.geojson
@@ -58,6 +58,9 @@
         "St. Andrew",
         "Saint Andrew Parish"
     ],
+    "name:epo_x_preferred":[
+        "Paro\u0125o Sankta Andreo"
+    ],
     "name:eus_x_preferred":[
         "Saint Andrew parrokia"
     ],
@@ -100,6 +103,9 @@
     "name:kor_x_preferred":[
         "\uc138\uc778\ud2b8\uc564\ub4dc\ub8e8 \uad50\uad6c"
     ],
+    "name:kor_x_variant":[
+        "\uc138\uc778\ud2b8\uc564\ub4dc\ub8e8\uad6c"
+    ],
     "name:lav_x_preferred":[
         "Sentendr\u016b pagasts"
     ],
@@ -120,6 +126,9 @@
     ],
     "name:nob_x_preferred":[
         "Saint Andrew prestegjeld"
+    ],
+    "name:nob_x_variant":[
+        "Saint Andrew Parish"
     ],
     "name:nor_x_preferred":[
         "Saint Andrew prestegjeld"
@@ -144,6 +153,9 @@
     ],
     "name:tam_x_preferred":[
         "\u0b9a\u0bc6\u0baf\u0bbf\u0ba9\u0bcd\u0b9f\u0bcd \u0b85\u0ba9\u0bcd\u0bb1\u0bc1 \u0baa\u0bb0\u0bbf\u0bb7\u0bcd"
+    ],
+    "name:tam_x_variant":[
+        "\u0b9a\u0bc6\u0baf\u0bbf\u0ba9\u0bcd\u0b9f\u0bcd  \u0b85\u0ba9\u0bcd\u0bb1\u0bc1 \u0baa\u0bb0\u0bbf\u0bb7\u0bcd"
     ],
     "name:tel_x_preferred":[
         "\u0c38\u0c46\u0c2f\u0c3f\u0c02\u0c1f\u0c4d \u0c06\u0c02\u0c21\u0c4d\u0c30\u0c4d\u0c2f\u0c42 \u0c2a\u0c3e\u0c30\u0c3f\u0c37\u0c4d"
@@ -288,7 +300,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1636506372,
+    "wof:lastmodified":1690914890,
     "wof:name":"Saint Andrew",
     "wof:parent_id":85632569,
     "wof:placetype":"region",

--- a/data/856/804/49/85680449.geojson
+++ b/data/856/804/49/85680449.geojson
@@ -55,6 +55,12 @@
         "St. David",
         "Saint David Parish"
     ],
+    "name:epo_x_preferred":[
+        "Paro\u0125o Sankta Davido"
+    ],
+    "name:eus_x_preferred":[
+        "Saint David parrokia"
+    ],
     "name:fas_x_preferred":[
         "\u0633\u0646\u062a \u062f\u06cc\u0648\u06cc\u062f \u067e\u0631\u06cc\u0634\u060c \u0633\u0646\u062a \u0648\u06cc\u0646\u0633\u0646\u062a \u0648 \u06af\u0631\u0646\u0627\u062f\u06cc\u0646\u200c\u0647\u0627"
     ],
@@ -94,6 +100,9 @@
     "name:kor_x_preferred":[
         "\uc138\uc778\ud2b8\ub370\uc774\ube44\ub4dc \uad50\uad6c"
     ],
+    "name:kor_x_variant":[
+        "\uc138\uc778\ud2b8\ub370\uc774\ube44\ub4dc\uad6c"
+    ],
     "name:lav_x_preferred":[
         "Sentdeivida pagasts"
     ],
@@ -115,6 +124,9 @@
     "name:nob_x_preferred":[
         "Saint David prestegjeld"
     ],
+    "name:nob_x_variant":[
+        "Saint David Parish"
+    ],
     "name:nor_x_preferred":[
         "Saint David prestegjeld"
     ],
@@ -126,6 +138,9 @@
     ],
     "name:rus_x_preferred":[
         "\u0421\u0435\u043d\u0442-\u0414\u044d\u0432\u0438\u0434"
+    ],
+    "name:rus_x_variant":[
+        "\u0421\u0435\u043d\u0442-\u0414\u0435\u0439\u0432\u0438\u0434"
     ],
     "name:sin_x_preferred":[
         "\u0dc1\u0dcf\u0db1\u0dca\u0dad \u0da9\u0dda\u0dc0\u0dd2\u0da9\u0dca \u0db4\u0dca\u200d\u0dbb\u0dcf\u0db1\u0dca\u0dad\u0dba"
@@ -282,7 +297,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1636506373,
+    "wof:lastmodified":1690914891,
     "wof:name":"Saint David",
     "wof:parent_id":85632569,
     "wof:placetype":"region",

--- a/data/856/804/51/85680451.geojson
+++ b/data/856/804/51/85680451.geojson
@@ -55,6 +55,12 @@
         "St. George",
         "Saint George Parish"
     ],
+    "name:epo_x_preferred":[
+        "Paro\u0125o Sankta Georgo"
+    ],
+    "name:eus_x_preferred":[
+        "Saint George parrokia"
+    ],
     "name:fas_x_preferred":[
         "\u0633\u0646\u062a \u062c\u0648\u0631\u062c"
     ],
@@ -98,6 +104,9 @@
     "name:kor_x_preferred":[
         "\uc138\uc778\ud2b8\uc870\uc9c0 \uad50\uad6c"
     ],
+    "name:kor_x_variant":[
+        "\uc138\uc778\ud2b8\uc870\uc9c0\uad6c"
+    ],
     "name:lav_x_preferred":[
         "Sentd\u017eord\u017ea pagasts"
     ],
@@ -118,6 +127,9 @@
     ],
     "name:nob_x_preferred":[
         "Saint George prestegjeld"
+    ],
+    "name:nob_x_variant":[
+        "Saint George Parish"
     ],
     "name:nor_x_preferred":[
         "Saint George prestegjeld"
@@ -142,6 +154,9 @@
     ],
     "name:tam_x_preferred":[
         "\u0b9a\u0bc6\u0baf\u0bbf\u0ba9\u0bcd\u0b9f\u0bcd George  \u0baa\u0bb0\u0bbf\u0bb7\u0bcd"
+    ],
+    "name:tam_x_variant":[
+        "\u0b9a\u0bc6\u0baf\u0bbf\u0ba9\u0bcd\u0b9f\u0bcd George \u0baa\u0bb0\u0bbf\u0bb7\u0bcd"
     ],
     "name:tel_x_preferred":[
         "\u0c38\u0c46\u0c2f\u0c3f\u0c02\u0c1f\u0c4d \u0c1c\u0c3e\u0c30\u0c4d\u0c1c\u0c3f \u0c2a\u0c3e\u0c30\u0c3f\u0c37\u0c4d"
@@ -286,7 +301,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1636506372,
+    "wof:lastmodified":1690914889,
     "wof:name":"Saint George",
     "wof:parent_id":85632569,
     "wof:placetype":"region",

--- a/data/856/804/57/85680457.geojson
+++ b/data/856/804/57/85680457.geojson
@@ -55,6 +55,12 @@
         "St. Patrick",
         "Saint Patrick Parish"
     ],
+    "name:epo_x_preferred":[
+        "Paro\u0125o Sankta Patriko"
+    ],
+    "name:eus_x_preferred":[
+        "Saint Patrick parrokia"
+    ],
     "name:fas_x_preferred":[
         "\u0633\u0646\u062a \u067e\u0627\u062a\u0631\u06cc\u06a9 \u067e\u0631\u06cc\u0634\u060c \u0633\u0646\u062a \u0648\u06cc\u0646\u0633\u0646\u062a \u0648 \u06af\u0631\u0646\u0627\u062f\u06cc\u0646\u200c\u0647\u0627"
     ],
@@ -94,6 +100,9 @@
     "name:kor_x_preferred":[
         "\uc138\uc778\ud2b8\ud328\ud2b8\ub9ad \uad50\uad6c"
     ],
+    "name:kor_x_variant":[
+        "\uc138\uc778\ud2b8\ud328\ud2b8\ub9ad\uad6c"
+    ],
     "name:lav_x_preferred":[
         "Sentpatrika pagasts"
     ],
@@ -114,6 +123,9 @@
     ],
     "name:nob_x_preferred":[
         "Saint Patrick prestegjeld"
+    ],
+    "name:nob_x_variant":[
+        "Saint Patrick Parish"
     ],
     "name:nor_x_preferred":[
         "Saint Patrick prestegjeld"
@@ -282,7 +294,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1636506372,
+    "wof:lastmodified":1690914888,
     "wof:name":"Saint Patrick",
     "wof:parent_id":85632569,
     "wof:placetype":"region",

--- a/data/890/429/321/890429321.geojson
+++ b/data/890/429/321/890429321.geojson
@@ -22,8 +22,17 @@
     "name:ara_x_preferred":[
         "\u0628\u0648\u0631\u062a \u0625\u0644\u064a\u0632\u0627\u0628\u064a\u062b"
     ],
+    "name:arz_x_preferred":[
+        "\u0628\u0648\u0631\u062a \u0627\u0644\u064a\u0632\u0627\u0628\u064a\u062b"
+    ],
+    "name:ast_x_preferred":[
+        "Port Elizabeth"
+    ],
     "name:bel_x_preferred":[
         "\u0413\u043e\u0440\u0430\u0434 \u041f\u043e\u0440\u0442-\u042d\u043b\u0456\u0437\u0430\u0431\u0435\u0442"
+    ],
+    "name:bel_x_variant":[
+        "\u041f\u043e\u0440\u0442-\u042d\u043b\u0456\u0437\u0430\u0431\u0435\u0442"
     ],
     "name:ceb_x_preferred":[
         "Port Elizabeth"
@@ -42,6 +51,9 @@
     ],
     "name:heb_x_preferred":[
         "\u05e4\u05d5\u05e8\u05d8 \u05d0\u05dc\u05d9\u05d6\u05d1\u05ea"
+    ],
+    "name:ita_x_preferred":[
+        "Port Elizabeth"
     ],
     "name:jpn_x_preferred":[
         "\u30dd\u30fc\u30c8\u30fb\u30a8\u30ea\u30b6\u30d9\u30b9"
@@ -115,7 +127,7 @@
         }
     ],
     "wof:id":890429321,
-    "wof:lastmodified":1582393041,
+    "wof:lastmodified":1690914895,
     "wof:name":"Port Elizabeth",
     "wof:parent_id":85680437,
     "wof:placetype":"locality",

--- a/data/890/429/323/890429323.geojson
+++ b/data/890/429/323/890429323.geojson
@@ -30,14 +30,35 @@
     "name:ara_x_preferred":[
         "\u0643\u064a\u0646\u063a\u0633\u062a\u0627\u0648\u0646"
     ],
+    "name:arg_x_preferred":[
+        "Kingstown"
+    ],
+    "name:ary_x_preferred":[
+        "\u0643\u064a\u0646\u06ad\u0633\u0637\u0627\u0648\u0646"
+    ],
+    "name:arz_x_preferred":[
+        "\u0643\u064a\u0646\u062c\u0633\u062a\u0627\u0648\u0646"
+    ],
     "name:ast_x_preferred":[
+        "Kingstown"
+    ],
+    "name:avk_x_preferred":[
         "Kingstown"
     ],
     "name:aze_x_preferred":[
         "Kinqstaun"
     ],
+    "name:ban_x_preferred":[
+        "Kingstown"
+    ],
     "name:bel_x_preferred":[
         "\u0413\u043e\u0440\u0430\u0434 \u041a\u0456\u043d\u0433\u0441\u0442\u0430\u045e\u043d"
+    ],
+    "name:bel_x_variant":[
+        "\u041a\u0456\u043d\u0433\u0441\u0442\u0430\u045e\u043d"
+    ],
+    "name:ben_x_preferred":[
+        "\u0995\u09bf\u0982\u09b8\u099f\u09be\u0989\u09a8"
     ],
     "name:bod_x_preferred":[
         "\u0f41\u0f72\u0f53\u0f0b\u0f66\u0f72\u0f0b\u0f50\u0f7c\u0f53\u0f0d"
@@ -105,6 +126,9 @@
     "name:gla_x_preferred":[
         "Kingstown"
     ],
+    "name:gle_x_preferred":[
+        "Kingstown"
+    ],
     "name:glg_x_preferred":[
         "Kingstown"
     ],
@@ -138,6 +162,9 @@
     "name:ind_x_preferred":[
         "Kingstown"
     ],
+    "name:isl_x_preferred":[
+        "Kingstown"
+    ],
     "name:ita_x_preferred":[
         "Kingstown"
     ],
@@ -159,14 +186,23 @@
     "name:lav_x_preferred":[
         "Kingstauna"
     ],
+    "name:lij_x_preferred":[
+        "Kingstown"
+    ],
     "name:lit_x_preferred":[
         "Kingstaunas"
     ],
     "name:lmo_x_preferred":[
         "Kingstown"
     ],
+    "name:mal_x_preferred":[
+        "\u0d15\u0d3f\u0d19\u0d4d\u0d38\u0d4d\u0d1f\u0d57\u0d7a"
+    ],
     "name:mar_x_preferred":[
         "\u0915\u093f\u0902\u0917\u094d\u0938\u091f\u093e\u0909\u0928"
+    ],
+    "name:mdf_x_preferred":[
+        "\u041a\u0438\u043d\u0433\u0441\u0442\u0430\u0432\u043d"
     ],
     "name:mkd_x_preferred":[
         "\u041a\u0438\u043d\u0433\u0441\u0442\u0430\u0443\u043d"
@@ -243,6 +279,9 @@
     "name:spa_x_preferred":[
         "Kingstown"
     ],
+    "name:srd_x_preferred":[
+        "Kingstown"
+    ],
     "name:srp_x_preferred":[
         "\u041a\u0438\u043d\u0433\u0441\u0442\u0430\u0443\u043d"
     ],
@@ -267,8 +306,14 @@
     "name:tur_x_preferred":[
         "Kingstown"
     ],
+    "name:udm_x_preferred":[
+        "\u041a\u0438\u043d\u0433\u0441\u0442\u0430\u0443\u043d"
+    ],
     "name:ukr_x_preferred":[
         "\u041a\u0456\u043d\u0433\u0441\u0442\u0430\u0443\u043d"
+    ],
+    "name:ukr_x_variant":[
+        "\u041a\u0456\u043d\u0491\u0441\u0442\u0430\u0443\u043d"
     ],
     "name:urd_x_preferred":[
         "\u06a9\u0646\u06af\u0632 \u0679\u0627\u0624\u0646"
@@ -284,6 +329,9 @@
     ],
     "name:war_x_preferred":[
         "Kingstown"
+    ],
+    "name:wuu_x_preferred":[
+        "\u91d1\u65af\u6566"
     ],
     "name:xmf_x_preferred":[
         "\u10d9\u10d8\u10dc\u10d2\u10e1\u10e2\u10d0\u10e3\u10dc\u10d8"
@@ -343,7 +391,7 @@
         }
     ],
     "wof:id":890429323,
-    "wof:lastmodified":1607390885,
+    "wof:lastmodified":1690914893,
     "wof:name":"Kingstown",
     "wof:parent_id":85680451,
     "wof:placetype":"locality",

--- a/data/890/429/325/890429325.geojson
+++ b/data/890/429/325/890429325.geojson
@@ -28,6 +28,9 @@
     "name:eng_x_preferred":[
         "Dovers"
     ],
+    "name:jpn_x_preferred":[
+        "\u30c9\u30fc\u30d0\u30fc\u30ba"
+    ],
     "name:pol_x_preferred":[
         "Dovers"
     ],
@@ -56,7 +59,7 @@
         }
     ],
     "wof:id":890429325,
-    "wof:lastmodified":1566644092,
+    "wof:lastmodified":1690914894,
     "wof:name":"Dovers",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/890/429/327/890429327.geojson
+++ b/data/890/429/327/890429327.geojson
@@ -34,11 +34,17 @@
     "name:eng_x_preferred":[
         "Chateaubelair"
     ],
+    "name:fas_x_preferred":[
+        "\u0634\u0627\u062a\u0648\u0628\u0644\u06cc\u0631"
+    ],
     "name:fra_x_preferred":[
         "Chateaubelair"
     ],
     "name:heb_x_preferred":[
         "\u05e9\u05d0\u05d8\u05d5\u05d1\u05dc\u05d9\u05d9\u05e8"
+    ],
+    "name:ita_x_preferred":[
+        "Chateaubelair"
     ],
     "name:jpn_x_preferred":[
         "\u30c1\u30e3\u30c8\u30fc\u30d9\u30ec\u30a2"
@@ -98,7 +104,7 @@
         }
     ],
     "wof:id":890429327,
-    "wof:lastmodified":1566644092,
+    "wof:lastmodified":1690914894,
     "wof:name":"Chateaubelair",
     "wof:parent_id":85680449,
     "wof:placetype":"locality",

--- a/data/890/444/831/890444831.geojson
+++ b/data/890/444/831/890444831.geojson
@@ -31,6 +31,12 @@
     "name:eng_x_preferred":[
         "Biabou"
     ],
+    "name:fas_x_preferred":[
+        "\u0628\u06cc\u0627\u0628\u0648"
+    ],
+    "name:jpn_x_preferred":[
+        "\u30d3\u30a2\u30d6\u30fc"
+    ],
     "name:lit_x_preferred":[
         "Biabu"
     ],
@@ -75,7 +81,7 @@
         }
     ],
     "wof:id":890444831,
-    "wof:lastmodified":1566644092,
+    "wof:lastmodified":1690914893,
     "wof:name":"Biabou",
     "wof:parent_id":-1,
     "wof:placetype":"locality",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2151.

This PR adds new name:* properties from Wikidata. Existing name properties were also cleaned up to remove duplicate name values when present.

This is one PR in a set of PRs needed to close the linked issue.. once approved, I'll merge. Per-language and updated feature counts are listed in https://github.com/whosonfirst-data/whosonfirst-data/issues/2151.