### PR TITLE
vc concordances, placetype local, and more

### DIFF
--- a/data/856/325/69/85632569.geojson
+++ b/data/856/325/69/85632569.geojson
@@ -1155,6 +1155,7 @@
         "hasc:id":"VC",
         "icao:code":"J8",
         "ioc:id":"VIN",
+        "iso:code":"VC",
         "itu:id":"VCT",
         "loc:id":"n82123205",
         "m49:code":"670",
@@ -1169,6 +1170,7 @@
         "wk:page":"Saint Vincent and the Grenadines",
         "wmo:id":"VG"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"VC",
     "wof:country_alpha3":"VCT",
     "wof:geom_alt":[
@@ -1189,7 +1191,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1694639573,
+    "wof:lastmodified":1695881233,
     "wof:name":"Saint Vincent and the Grenadines",
     "wof:parent_id":102191575,
     "wof:placetype":"country",

--- a/data/856/804/33/85680433.geojson
+++ b/data/856/804/33/85680433.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.008589,
-    "geom:area_square_m":103368689.013123,
+    "geom:area_square_m":103369113.183113,
     "geom:bbox":"-61.200162,13.197849,-61.123931,13.379952",
     "geom:latitude":13.278036,
     "geom:longitude":-61.154523,
@@ -273,14 +273,16 @@
         "gn:id":3577934,
         "gp:id":2347671,
         "hasc:id":"VC.CH",
+        "iso:code":"VC-01",
         "iso:id":"VC-01",
         "qs_pg:id":219630,
         "unlc:id":"VC-01",
         "wd:id":"Q2075188",
         "wk:page":"Charlotte Parish, Saint Vincent and the Grenadines"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"VC",
-    "wof:geomhash":"65213cec76d75d348db22aa08a3c9bb8",
+    "wof:geomhash":"d8c3c498759d85296a3d49f4beabbfab",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -295,7 +297,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1690914889,
+    "wof:lastmodified":1695884969,
     "wof:name":"Charlotte",
     "wof:parent_id":85632569,
     "wof:placetype":"region",

--- a/data/856/804/37/85680437.geojson
+++ b/data/856/804/37/85680437.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.003553,
-    "geom:area_square_m":42834519.295793,
+    "geom:area_square_m":42834041.675665,
     "geom:bbox":"-61.459828,12.58515,-61.131418,13.051174",
     "geom:latitude":12.860524,
     "geom:longitude":-61.28284,
@@ -241,13 +241,15 @@
         "gn:id":3577892,
         "gp:id":2347676,
         "hasc:id":"VC.GT",
+        "iso:code":"VC-06",
         "iso:id":"VC-06",
         "qs_pg:id":1083880,
         "wd:id":"Q2545297",
         "wk:page":"Grenadines Parish"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"VC",
-    "wof:geomhash":"fe63005eb606823f6f3cb5e68ec8d520",
+    "wof:geomhash":"b63b8d8e8361034d648c0c3b4781abcb",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -262,7 +264,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1690914890,
+    "wof:lastmodified":1695884969,
     "wof:name":"Grenadines",
     "wof:parent_id":85632569,
     "wof:placetype":"region",

--- a/data/856/804/43/85680443.geojson
+++ b/data/856/804/43/85680443.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.002807,
-    "geom:area_square_m":33791395.646107,
+    "geom:area_square_m":33790727.753991,
     "geom:bbox":"-61.271352,13.163366,-61.192773,13.239298",
     "geom:latitude":13.200909,
     "geom:longitude":-61.228754,
@@ -278,14 +278,16 @@
         "gn:id":3577822,
         "gp:id":2347672,
         "hasc:id":"VC.AN",
+        "iso:code":"VC-02",
         "iso:id":"VC-02",
         "qs_pg:id":1311991,
         "unlc:id":"VC-02",
         "wd:id":"Q2305115",
         "wk:page":"Saint Andrew Parish, Saint Vincent and the Grenadines"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"VC",
-    "wof:geomhash":"b3fdd0d7878211bff0876153ac04cbde",
+    "wof:geomhash":"cb0b1adb850d3e3653327a8c19c20b29",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -300,7 +302,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1690914890,
+    "wof:lastmodified":1695884969,
     "wof:name":"Saint Andrew",
     "wof:parent_id":85632569,
     "wof:placetype":"region",

--- a/data/856/804/49/85680449.geojson
+++ b/data/856/804/49/85680449.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.007664,
-    "geom:area_square_m":92221379.295449,
+    "geom:area_square_m":92221735.655581,
     "geom:bbox":"-61.270375,13.255334,-61.160828,13.380764",
     "geom:latitude":13.311945,
     "geom:longitude":-61.206616,
@@ -275,14 +275,16 @@
         "gn:id":3577821,
         "gp:id":2347673,
         "hasc:id":"VC.DA",
+        "iso:code":"VC-03",
         "iso:id":"VC-03",
         "qs_pg:id":219631,
         "unlc:id":"VC-03",
         "wd:id":"Q2412394",
         "wk:page":"Saint David Parish, Saint Vincent and the Grenadines"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"VC",
-    "wof:geomhash":"48985a338d5e96d5f7cfc026f1fcace3",
+    "wof:geomhash":"68f6e163cbbd967485e6914e490435ec",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -297,7 +299,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1690914891,
+    "wof:lastmodified":1695884969,
     "wof:name":"Saint David",
     "wof:parent_id":85632569,
     "wof:placetype":"region",

--- a/data/856/804/51/85680451.geojson
+++ b/data/856/804/51/85680451.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.004619,
-    "geom:area_square_m":55606708.328836,
+    "geom:area_square_m":55606714.449148,
     "geom:bbox":"-61.237904,13.132514,-61.135536,13.216687",
     "geom:latitude":13.174094,
     "geom:longitude":-61.185098,
@@ -279,14 +279,16 @@
         "gn:id":3577819,
         "gp:id":2347674,
         "hasc:id":"VC.GE",
+        "iso:code":"VC-04",
         "iso:id":"VC-04",
         "qs_pg:id":319285,
         "unlc:id":"VC-04",
         "wd:id":"Q2300294",
         "wk:page":"Saint George Parish, Saint Vincent and the Grenadines"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"VC",
-    "wof:geomhash":"8be15048ca73f1666e4429dda28e320c",
+    "wof:geomhash":"93486ccc242783c09a8a6641b28bf5cf",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -301,7 +303,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1690914889,
+    "wof:lastmodified":1695884969,
     "wof:name":"Saint George",
     "wof:parent_id":85632569,
     "wof:placetype":"region",

--- a/data/856/804/57/85680457.geojson
+++ b/data/856/804/57/85680457.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.003804,
-    "geom:area_square_m":45786539.810854,
+    "geom:area_square_m":45786908.300786,
     "geom:bbox":"-61.279368,13.18651,-61.187706,13.276009",
     "geom:latitude":13.237244,
     "geom:longitude":-61.242702,
@@ -272,14 +272,16 @@
         "gn:id":3577818,
         "gp:id":2347675,
         "hasc:id":"VC.PA",
+        "iso:code":"VC-05",
         "iso:id":"VC-05",
         "qs_pg:id":895014,
         "unlc:id":"VC-05",
         "wd:id":"Q1864637",
         "wk:page":"Saint Patrick Parish, Saint Vincent and the Grenadines"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"VC",
-    "wof:geomhash":"47356efb10513b214fb1f8462246bdc3",
+    "wof:geomhash":"97a3647b08cc89ee59c75e90028155bf",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -294,7 +296,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1690914888,
+    "wof:lastmodified":1695884969,
     "wof:name":"Saint Patrick",
     "wof:parent_id":85632569,
     "wof:placetype":"region",


### PR DESCRIPTION
Will fix a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2164. Sets wof:concordances_official, wof:concordances_official_alt, and wof:label_*_x_preferred properties, and wof:concordances{*:*} hashes when approprirate.